### PR TITLE
[Chore] Remove Cache-Control header from ListBreweries response

### DIFF
--- a/app/Http/Controllers/Api/V1/ListBreweries.php
+++ b/app/Http/Controllers/Api/V1/ListBreweries.php
@@ -42,9 +42,6 @@ class ListBreweries extends Controller
         return response()->json(
             BreweryResource::collection($breweries),
             Response::HTTP_OK,
-            [
-                'Cache-Control' => 'max-age=300, public',
-            ]
         );
     }
 }


### PR DESCRIPTION
## 📃 Description

This PR removes cache control from `/breweries` endpoint as it caused some responses to be duplicated when filters were applied.

## 🪵 Changelog

### 🗑️ Removed

- cache control header from `/breweries` endpoint
