### PR TITLE
[Feature] Add autocomplete endpoint for breweries and redirect to search

### DIFF
--- a/app/Http/Controllers/Api/V1/AutocompleteBreweries.php
+++ b/app/Http/Controllers/Api/V1/AutocompleteBreweries.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class AutocompleteBreweries extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
+    {
+        $query = $request->query('query');
+
+        Log::info('Redirecting autocomplete to search', ['query' => $query]);
+
+        return redirect()->route(
+            route: 'v1.breweries.search',
+            parameters: [
+                'query' => $query,
+            ],
+            status: 301,
+        );
+    }
+}

--- a/routes/api/v1/routes.php
+++ b/routes/api/v1/routes.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\V1\AutocompleteBreweries;
 use App\Http\Controllers\Api\V1\GetBreweriesMeta;
 use App\Http\Controllers\Api\V1\GetBrewery;
 use App\Http\Controllers\Api\V1\ListBreweries;
@@ -7,10 +8,11 @@ use App\Http\Controllers\Api\V1\RandomBrewery;
 use App\Http\Controllers\Api\V1\SearchBreweries;
 use Illuminate\Support\Facades\Route;
 
-Route::prefix('v1')->group(function () {
-    Route::get('/breweries', ListBreweries::class);
-    Route::get('/breweries/meta', GetBreweriesMeta::class);
-    Route::get('/breweries/random', RandomBrewery::class);
-    Route::get('/breweries/search', SearchBreweries::class);
-    Route::get('/breweries/{id}', GetBrewery::class);
+Route::name('v1.')->prefix('v1')->group(function () {
+    Route::get('/breweries', ListBreweries::class)->name('breweries.index');
+    Route::get('/breweries/autocomplete', AutocompleteBreweries::class)->name('breweries.autocomplete');
+    Route::get('/breweries/meta', GetBreweriesMeta::class)->name('breweries.meta');
+    Route::get('/breweries/random', RandomBrewery::class)->name('breweries.random');
+    Route::get('/breweries/search', SearchBreweries::class)->name('breweries.search');
+    Route::get('/breweries/{id}', GetBrewery::class)->name('breweries.show');
 });


### PR DESCRIPTION
## 📃 Description

Since `/autocomplete` was removed this PR provides a redirect to the `/search` endpoint to cut down on errors in the log and provide a better user experience.

## 🪵 Changelog

### ➕ Added

- redirect `/autocomplete` to `/search`
- route names
