### PR TITLE
[Fix] Update Cache-Control header separator from semicolons to commas

### DIFF
--- a/app/Http/Controllers/Api/V1/GetBreweriesMeta.php
+++ b/app/Http/Controllers/Api/V1/GetBreweriesMeta.php
@@ -56,7 +56,7 @@ class GetBreweriesMeta extends Controller
         return response()->json(
             data: $data,
             status: Response::HTTP_OK,
-            headers: ['Cache-Control' => 'public; max-age=300; etag'],
+            headers: ['Cache-Control' => 'public, max-age=300, etag'],
         );
     }
 }

--- a/app/Http/Controllers/Api/V1/GetBrewery.php
+++ b/app/Http/Controllers/Api/V1/GetBrewery.php
@@ -24,7 +24,7 @@ class GetBrewery extends Controller
         return response()->json(
             data: $brewery,
             status: Response::HTTP_OK,
-            headers: ['Cache-Control' => 'public; max-age=300; etag'],
+            headers: ['Cache-Control' => 'public, max-age=300, etag'],
         );
     }
 }

--- a/app/Http/Controllers/Api/V1/ListBreweries.php
+++ b/app/Http/Controllers/Api/V1/ListBreweries.php
@@ -24,7 +24,7 @@ class ListBreweries extends Controller
         return response()->json(
             data: BreweryResource::collection($breweries),
             status: Response::HTTP_OK,
-            headers: ['Cache-Control' => 'public; max-age=300; etag'],
+            headers: ['Cache-Control' => 'public, max-age=300, etag'],
         );
     }
 }

--- a/app/Http/Controllers/Api/V1/SearchBreweries.php
+++ b/app/Http/Controllers/Api/V1/SearchBreweries.php
@@ -28,7 +28,7 @@ class SearchBreweries extends Controller
         return response()->json(
             data: BreweryResource::collection($breweries),
             status: Response::HTTP_OK,
-            headers: ['Cache-Control' => 'public; max-age=300; etag'],
+            headers: ['Cache-Control' => 'public, max-age=300, etag'],
         );
     }
 }


### PR DESCRIPTION
## 📃 Description

Fix caching because colons over semicolons according to MDN (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control)