### PR TITLE
Testing more aggressive caching for api responses

### DIFF
--- a/app/Http/Controllers/Api/V1/GetBrewery.php
+++ b/app/Http/Controllers/Api/V1/GetBrewery.php
@@ -17,14 +17,15 @@ class GetBrewery extends Controller
      */
     public function __invoke(Request $request, string $id): JsonResponse
     {
-        $brewery = Cache::remember('brewery_'.$id, 300, function () use ($id) {
+        $brewery = Cache::remember('brewery_'.$id, config('platform.cache_control_max_age'), function () use ($id) {
             return new BreweryResource(Brewery::findOrFail($id));
         });
 
-        return response()->json(
-            data: $brewery,
-            status: Response::HTTP_OK,
-            headers: ['Cache-Control' => 'public, max-age=300, etag'],
-        );
+        return response()
+            ->json(
+                data: $brewery,
+                status: Response::HTTP_OK,
+                headers: ['Cache-Control' => 'public, max-age='.config('platform.cache_control_max_age')],
+            );
     }
 }

--- a/config/platform.php
+++ b/config/platform.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'cache_control_max_age' => (int) env('CACHE_CONTROL_MAX_AGE', 86400), // 1 day
+];


### PR DESCRIPTION
## 📃 Description

This PR implements a longer more aggressive caching strategy or API responses. This also drops the `etag` attribute, the best practice is to use this attribute with a timestamp and because we don't have any on the brewery data it was removed.

Initial testing shows responses on `GET` `/breweries/{id}` endpoint dropping from ~`220ms` to as low as `16ms`. This is probably the best case scenario as this was done in my home lab.

## 🪵 Changelog

### ➕ Added

- `platform.php` to collect any platform related configurations we want to define

### ✏️ Changed

- increased the cache time from `300s` (5 minutes) to `84600s` (24 hours)

### 🗑️ Removed

- `etag` header attribute from `GET` `/breweries/{id}` endpoint
