### PR TITLE
fix: validate brewery sorting

### DIFF
--- a/app/Http/Requests/V1/BreweryFilterRequest.php
+++ b/app/Http/Requests/V1/BreweryFilterRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\V1;
 
+use App\Rules\BrewerySort as BrewerySortRule;
 use App\Rules\BreweryType as BreweryTypeRule;
 use App\Rules\Coordinates as CoordinatesRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -26,7 +27,7 @@ class BreweryFilterRequest extends FormRequest
         return [
             'per_page' => ['sometimes', 'required', 'integer', 'min:1', 'max:200'],
             'page' => ['sometimes', 'required', 'integer', 'min:1'],
-            'sort' => ['sometimes', 'required', 'string'],
+            'sort' => ['sometimes', 'required', 'string', new BrewerySortRule],
 
             // filters
             'by_city' => ['sometimes', 'required', 'string', 'min:3', 'max:255'],

--- a/app/Models/Traits/V1/BreweryFilters.php
+++ b/app/Models/Traits/V1/BreweryFilters.php
@@ -77,7 +77,9 @@ trait BreweryFilters
                     ->toArray();
 
                 foreach ($values as $value) {
-                    $query->orderBy($value[0], $value[1] ?? 'asc');
+                    $field = $value[0] === 'type' ? 'brewery_type' : $value[0];
+
+                    $query->orderBy($field, $value[1] ?? 'asc');
                 }
             });
     }

--- a/app/Rules/BrewerySort.php
+++ b/app/Rules/BrewerySort.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class BrewerySort implements ValidationRule
+{
+    public const SORTABLE_FIELDS = [
+        'id',
+        'name',
+        'brewery_type',
+        'type',
+        'city',
+        'state_province',
+        'postal_code',
+        'country',
+    ];
+
+    private const SORT_DIRECTIONS = ['asc', 'desc'];
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value)) {
+            return;
+        }
+
+        foreach (explode(',', $value) as $sort) {
+            $parts = array_map('trim', explode(':', $sort));
+            $field = $parts[0];
+            $direction = strtolower($parts[1] ?? 'asc');
+
+            if (count($parts) > 2 || ! in_array($field, self::SORTABLE_FIELDS, true)) {
+                $fail('The :attribute contains an invalid sort field. Valid fields are: '.implode(', ', self::SORTABLE_FIELDS).'.');
+
+                return;
+            }
+
+            if (! in_array($direction, self::SORT_DIRECTIONS, true)) {
+                $fail('The :attribute direction must be asc or desc.');
+
+                return;
+            }
+        }
+    }
+}

--- a/tests/Feature/Api/V1/GetBreweries/SortingTest.php
+++ b/tests/Feature/Api/V1/GetBreweries/SortingTest.php
@@ -47,3 +47,33 @@ test('breweries can be sorted by multiple fields', function () {
         ['name' => 'Alpha Brewing', 'city' => 'Portland'],
     ]);
 });
+
+test('breweries can be sorted by the documented type alias', function () {
+    createBrewery(['name' => 'Zebra Brewing', 'brewery_type' => 'micro']);
+    createBrewery(['name' => 'Alpha Brewing', 'brewery_type' => 'regional']);
+    createBrewery(['name' => 'Beta Brewing', 'brewery_type' => 'brewpub']);
+
+    $response = $this->getJson('/v1/breweries?sort=type,name:asc');
+
+    $response->assertOk();
+    $breweries = collect($response->json());
+    expect($breweries->pluck('brewery_type')->toArray())->toBe([
+        'brewpub',
+        'micro',
+        'regional',
+    ]);
+});
+
+test('invalid brewery sorts return a validation error', function (string $sort) {
+    $response = $this->getJson('/v1/breweries?'.http_build_query(['sort' => $sort]));
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors('sort');
+})->with([
+    'invalid direction' => 'name:invalid',
+    'invalid field' => 'created_at:asc',
+    'missing field' => ':asc',
+    'missing direction' => 'name:',
+    'too many separators' => 'name:asc:desc',
+    'trailing separator' => 'name:asc,',
+]);


### PR DESCRIPTION
## Summary
- validate comma-separated brewery sort fields and directions before building the query
- map the documented `type` sort alias to `brewery_type`
- cover valid aliases and malformed sort expressions with feature tests

Closes #92

## Testing
- `vendor/bin/sail artisan test --compact`
- `vendor/bin/sail bin pint --dirty --format agent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated brewery sorting with supported fields and ascending or descending directions.
  * Sorting by `type` now correctly orders results by brewery type.

* **Bug Fixes**
  * Invalid sort fields, directions, and formats now return a clear validation error instead of being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->